### PR TITLE
表示名を Rio Miyata から Ryo Miyata に変更

### DIFF
--- a/components/Footer.jsx
+++ b/components/Footer.jsx
@@ -27,7 +27,7 @@ const Footer = () => {
       >
         <Flex justifyContent="space-between" alignItems="center" fontSize="sm" color={textSecondary}>
           <Text>
-            &copy; {new Date().getFullYear()} Rio Miyata
+            &copy; {new Date().getFullYear()} Ryo Miyata
           </Text>
           <HStack spacing={5}>
             <Link

--- a/docs/SPEC.md
+++ b/docs/SPEC.md
@@ -163,7 +163,7 @@ const idx = Math.min(tier, TYPING_SPEEDS.length - 1);
       width={80}
       height={80}
       className="round-image"
-      alt="Rio Miyata"
+      alt="Ryo Miyata"
     />
   </Box>
   <VStack align="start" spacing={4}>

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -27,7 +27,7 @@ const Home: NextPage<Props> = ({ posts }) => {
   return (
     <Box className="fade-in">
       <Head>
-        <title>Rio Miyata's Website</title>
+        <title>Ryo Miyata's Website</title>
       </Head>
       <Box
         maxWidth="720px"
@@ -59,7 +59,7 @@ const Home: NextPage<Props> = ({ posts }) => {
         <Flex mb={16} alignItems="center">
           <Box>
             <Text fontSize="3xl" fontWeight="700" letterSpacing="-0.02em">
-              Rio Miyata
+              Ryo Miyata
             </Text>
             <Text fontSize="md" fontWeight="500" color={textSecondary} mt={1}>
               Software Engineer
@@ -74,7 +74,7 @@ const Home: NextPage<Props> = ({ posts }) => {
               priority={false}
               loading="lazy"
               className="round-image"
-              alt="Rio Miyata"
+              alt="Ryo Miyata"
             />
           </Box>
         </Flex>


### PR DESCRIPTION
## Summary
- サイト上の表示名を「Rio Miyata」から「Ryo Miyata」に変更
- 対象箇所: ページタイトル、ヒーローセクション、画像alt属性、フッターコピーライト、ドキュメント
- 本名との一致・SEO向上・note.comハンドル(miyata_ryo3)との整合性が目的

## Test plan
- [ ] `npm run build` が成功すること（確認済み）
- [ ] ブラウザタブのタイトルが「Ryo Miyata's Website」と表示されること
- [ ] ヒーローセクションに「Ryo Miyata」と表示されること
- [ ] フッターに「© 2026 Ryo Miyata」と表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated name references from "Rio Miyata" to "Ryo Miyata" across the site, including footer, homepage title, and accessibility labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->