### PR TITLE
Interestsセクションの中身を旧内容に戻す

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -136,20 +136,7 @@ const Home: NextPage<Props> = ({ posts }) => {
             <Heading as="h2" fontSize="2xl" fontWeight="900">
               /Interests
             </Heading>
-            <HStack spacing={3} flexWrap="wrap">
-              {[
-                "Morning coffee",
-                "Campfire cooking",
-                "Hot spring hopping",
-                "The beauty of physics",
-                "First principles",
-                "Running",
-              ].map((item) => (
-                <Text key={item} fontSize="md">
-                  #{item}
-                </Text>
-              ))}
-            </HStack>
+            <Text>#Thinking #FoodTouring #Camping #Traveling</Text>
           </VStack>
 
           {/* Posts */}


### PR DESCRIPTION
## Summary
- Interestsの中身を `8706f7d` 以前の旧内容に復旧
- `<Text>#Thinking #FoodTouring #Camping #Traveling</Text>` の単一行テキスト形式

## Test plan
- [ ] `npm run build` が通る
- [ ] `/` のInterestsセクションが `#Thinking #FoodTouring #Camping #Traveling` と1行で表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)