### PR TITLE
/Contact セクションを旧内容で復活

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -254,6 +254,32 @@ const Home: NextPage<Props> = ({ posts }) => {
               </Button>
             </Link>
           </Flex>
+
+          {/* Contact */}
+          <VStack align="start" spacing={5} mb={12}>
+            <Heading as="h2" fontSize="2xl" fontWeight="900">
+              /Contact 📬
+            </Heading>
+          </VStack>
+          <Flex justifyContent="center" mb={12}>
+            <Button
+              as="a"
+              href="https://x.com/WebDev_Ryo"
+              target="_blank"
+              rel="noopener noreferrer"
+              p={5}
+              fontWeight="600"
+              borderRadius="25px"
+              bg="#664D03"
+              color="#EDDFD6"
+              boxShadow="2px 2px 10px rgb(102, 77, 3, 0.3)"
+              _hover={{ opacity: 0.7 }}
+            >
+              <Flex alignItems="center">
+                <Text ml={2}>TwitterでDMを送る</Text>
+              </Flex>
+            </Button>
+          </Flex>
         </Box>
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- `464f7f9` で削除されていた「TwitterでDMを送る」セクションを復活
- `fe719a5` (2023-09-19) の原文スタイル: 見出し `/Contact 📬`、茶色 `#664D03` ボタン、beige 文字
- Posts(`#8505b0`)/Creations(`#0530b0`)と同時代の配色セットで統一
- X ハンドルは `riomiyatta` → 現在の `WebDev_Ryo` に更新

## Test plan
- [ ] `npm run build` が通る
- [ ] `/` の Creations の下に `/Contact 📬` 見出しと茶色ボタンが表示される
- [ ] ボタン押下で `https://x.com/WebDev_Ryo` が新規タブで開く

🤖 Generated with [Claude Code](https://claude.com/claude-code)