### PR TITLE
About Meの2段落目を削除し1段落構成に

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -87,22 +87,13 @@ const Home: NextPage<Props> = ({ posts }) => {
             <Heading as="h2" fontSize="2xl" fontWeight="900">
               /About Me
             </Heading>
-            <VStack align="start" spacing={4}>
-              <Text>
-                I&apos;m the younger of a pair of twins, which might be why I&apos;ve
-                always felt most alive turning ideas into something real. My head
-                runs on a steady stream of half-formed concepts, and programming
-                is the craft that lets me pull them out and shape them into apps
-                people can actually use.
-              </Text>
-              <Text>
-                Outside of building things, I start most mornings with a slow
-                pour-over coffee, chipping away at whatever side project has my
-                attention that week. When I can, I escape to hot springs around
-                Japan or hunt down cozy local cafés — the quiet places that make
-                it easier to think.
-              </Text>
-            </VStack>
+            <Text>
+              I&apos;m the younger of a pair of twins, which might be why I&apos;ve
+              always felt most alive turning ideas into something real. My head
+              runs on a steady stream of half-formed concepts, and programming
+              is the craft that lets me pull them out and shape them into apps
+              people can actually use.
+            </Text>
           </VStack>
 
           {/* Bio */}


### PR DESCRIPTION
## Summary
- About Meセクションの2段落目(コーヒー・温泉・カフェの話)を削除
- 1段落のみになったため不要な VStack ラッパーも除去

## Test plan
- [ ] \`npm run build\` が通る
- [ ] トップページ /About Me に1段落のみ表示される
- [ ] /Bio セクションとの間の余白が崩れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)