### PR TITLE
ページ遷移時のスクロールバー起因の幅ズレを修正

### DIFF
--- a/styles/global.css
+++ b/styles/global.css
@@ -3,6 +3,11 @@
 @tailwind utilities;
 @import "./colors.css";
 
+html {
+  overflow-y: scroll;
+  scrollbar-gutter: stable;
+}
+
 html:before,
 body:before {
   content: '';


### PR DESCRIPTION
## Summary
- \`/\` (長い) と \`/post\` \`/work\` (短い) を行き来する際にスクロールバー出現/消失でビューポート幅が変わり、\`mx=auto\` のコンテンツが横にズレていた
- \`html\` に \`overflow-y: scroll\` + \`scrollbar-gutter: stable\` を設定し常にスクロールバー領域を確保

## Test plan
- [ ] \`npm run build\` が通る
- [ ] home → /post → home に戻ったときに本文が横にズレないこと
- [ ] home → /work → home で同様にズレないこと
- [ ] ダーク/ライトモードで見た目に問題が出ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)