### PR TITLE
Interestsを元の1行表記に戻す

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -127,20 +127,7 @@ const Home: NextPage<Props> = ({ posts }) => {
             <Heading as="h2" fontSize="2xl" fontWeight="900">
               /Interests
             </Heading>
-            <HStack spacing={3} flexWrap="wrap">
-              {[
-                "Morning coffee",
-                "Campfire cooking",
-                "Hot spring hopping",
-                "The beauty of physics",
-                "First principles",
-                "Running",
-              ].map((item) => (
-                <Text key={item} fontSize="md">
-                  #{item}
-                </Text>
-              ))}
-            </HStack>
+            <Text>#Thinking #FoodTouring #Camping #Traveling</Text>
           </VStack>
 
           {/* Posts */}


### PR DESCRIPTION
## Summary
- /Interests を6項目HStack(Morning coffee 等)から元の1行 Text \`#Thinking #FoodTouring #Camping #Traveling\` に戻す

## Test plan
- [ ] \`npm run build\` が通る
- [ ] トップページ /Interests に1行で4ハッシュタグが表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified the Interests section display by replacing dynamic tag generation with a static tag list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->