### PR TITLE
PostsにQiita記事「Heroku/Rails+MySQLデプロイ手順」を追加

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -148,6 +148,18 @@ const Home: NextPage<Props> = ({ posts }) => {
               >
                 人を表すソウルバンドトークンとよばれるNFT (2023.1.23)
               </Box>
+              <Box
+                as="a"
+                href="https://qiita.com/MiyataRyo/items/6a5f6aa510afddae0701"
+                target="_blank"
+                rel="noopener noreferrer"
+                color={linkColor}
+                textDecoration="underline"
+                fontSize="16px"
+                _hover={{ opacity: 0.7 }}
+              >
+                Herokuへのデプロイ手順｜Rails + MySQL (2020.3.23)
+              </Box>
             </VStack>
           </VStack>
           <Flex justifyContent="center" mb={6}>

--- a/pages/post/index.js
+++ b/pages/post/index.js
@@ -42,6 +42,23 @@ const PostIndex = ({ posts }) => {
               <Text fontSize="md" fontWeight="600">人を表すソウルバンドトークンとよばれるNFT</Text>
             </VStack>
           </Box>
+          <Box
+            as="a"
+            href="https://qiita.com/MiyataRyo/items/6a5f6aa510afddae0701"
+            target="_blank"
+            rel="noopener noreferrer"
+            w="100%"
+            pb={5}
+            borderBottom="1px solid"
+            borderColor={borderColor}
+            transition="color 0.2s"
+            _hover={{ color: linkColor }}
+          >
+            <VStack align="start" spacing={2}>
+              <Text fontSize="sm" color={textSecondary}>2020.3.23</Text>
+              <Text fontSize="md" fontWeight="600">Herokuへのデプロイ手順｜Rails + MySQL</Text>
+            </VStack>
+          </Box>
         </VStack>
       </Box>
     </Box>


### PR DESCRIPTION
## Summary
- トップページの /Posts に Qiita 記事 \`Herokuへのデプロイ手順｜Rails + MySQL\` (2020.3.23) を追加
- /post 一覧ページにも同記事を追加

## Test plan
- [ ] \`npm run build\` が通る
- [ ] トップページ /Posts に2件(note 2023.1.23 / Qiita 2020.3.23)が表示される
- [ ] /post ページにも同記事が表示され、リンクが Qiita に飛ぶ

🤖 Generated with [Claude Code](https://claude.com/claude-code)