### PR TITLE
creations に DAILY COWORKER を追加

### DIFF
--- a/docs/superpowers/plans/2026-05-01-contact-form.md
+++ b/docs/superpowers/plans/2026-05-01-contact-form.md
@@ -1,0 +1,1401 @@
+# お問い合わせフォーム Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Google Forms 外部リンクを廃止し、Resend + Cloudflare Turnstile による自前のお問い合わせフォーム `/contact` を Next.js Pages Router 上に実装する。
+
+**Architecture:** `pages/contact.tsx`（薄いラッパー）→ `components/ContactForm.jsx`（idle/submitting/done/error の state machine）→ `pages/api/contact.ts`（Turnstile 検証 → Resend 送信）。バリデーションは `lib/validateContact.ts` の純関数を API・クライアント双方で共有。
+
+**Tech Stack:** Next.js 13.2.4 (Pages Router) / TypeScript 5.3 / Tailwind / Resend SDK / Cloudflare Turnstile / Jest 29 + React Testing Library + next/jest
+
+**Spec:** `docs/superpowers/specs/2026-05-01-contact-form-design.md`
+
+---
+
+## 事前準備（実装着手前のユーザー作業）
+
+1. Resend API キー発行（https://resend.com/api-keys）
+2. Cloudflare Turnstile サイト追加 → Site Key / Secret Key 発行
+3. プロジェクトルートの `.env` に以下を追記：
+
+```
+RESEND_API_KEY=re_xxxxxxxxxxxx
+TURNSTILE_SITE_KEY=0xAAAAAAAA...
+TURNSTILE_SECRET_KEY=0xBBBBBBBB...
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=0xAAAAAAAA...
+CONTACT_TO_EMAIL=miyata09x0084@gmail.com
+```
+
+`TURNSTILE_SITE_KEY` と `NEXT_PUBLIC_TURNSTILE_SITE_KEY` は同値。後者だけがクライアント露出する。テストではこれら本物の値は使わずモックする。
+
+---
+
+## File Structure
+
+| 種別 | パス | 責務 |
+|---|---|---|
+| 新規 | `jest.config.js` | next/jest プリセット呼び出し |
+| 新規 | `jest.setup.ts` | `@testing-library/jest-dom` を import |
+| 修正 | `package.json` | devDeps + test scripts 追加 |
+| 修正 | `tsconfig.json` | stale `pages/api/contact.js` 参照を削除 |
+| 新規 | `lib/validateContact.ts` | `validate()` 純関数（API・クライアント共有） |
+| 新規 | `lib/__tests__/validateContact.test.ts` | validate() の Jest テスト |
+| 新規 | `pages/api/contact.ts` | API ルート（Turnstile 検証 + Resend 送信） |
+| 新規 | `pages/api/__tests__/contact.test.ts` | API ルートの Jest テスト |
+| 新規 | `components/ContactForm.jsx` | フォーム本体 state machine |
+| 新規 | `components/__tests__/ContactForm.test.jsx` | コンポーネント Jest テスト |
+| 新規 | `pages/contact.tsx` | `/contact` ページ薄ラッパー |
+| 修正 | `pages/index.tsx` | contact セクションのリンク差し替え |
+
+---
+
+## Task 1: テスト基盤の導入
+
+**Files:**
+- Modify: `package.json`
+- Create: `jest.config.js`
+- Create: `jest.setup.ts`
+- Create: `lib/__tests__/sanity.test.ts`（動作確認用、Task 2 開始時に削除）
+
+- [ ] **Step 1: Jest 関連 devDependencies のインストール**
+
+```bash
+npm install --save-dev jest@^29.7.0 jest-environment-jsdom@^29.7.0 @testing-library/react@^14.2.0 @testing-library/jest-dom@^6.4.0 @testing-library/user-event@^14.5.0 @types/jest@^29.5.0
+```
+
+期待: `added N packages` が表示。エラーなし。
+
+- [ ] **Step 2: jest.config.js を作成**
+
+```js
+const nextJest = require('next/jest');
+
+const createJestConfig = nextJest({
+  dir: './',
+});
+
+/** @type {import('jest').Config} */
+const customJestConfig = {
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  testEnvironment: 'jest-environment-jsdom',
+  moduleDirectories: ['node_modules', '<rootDir>'],
+};
+
+module.exports = createJestConfig(customJestConfig);
+```
+
+正しい Jest オプション名は `setupFilesAfterEnv`（テストフレームワーク初期化後に実行）。`setupFiles` は初期化前なので RTL 用途では不可。
+
+- [ ] **Step 3: jest.setup.ts を作成**
+
+```ts
+import '@testing-library/jest-dom';
+```
+
+- [ ] **Step 4: package.json に test scripts と devDependencies を反映**
+
+`scripts` ブロックに追加（既存3行の下）：
+
+```json
+"test": "jest",
+"test:watch": "jest --watch"
+```
+
+`devDependencies` には Step 1 で `npm install --save-dev` を使ったので自動追記されている。確認のみ。
+
+- [ ] **Step 5: sanity test を作成**
+
+`lib/__tests__/sanity.test.ts`:
+
+```ts
+describe('sanity', () => {
+  it('runs', () => {
+    expect(1 + 1).toBe(2);
+  });
+});
+```
+
+- [ ] **Step 6: テスト実行で動作確認**
+
+```bash
+npm test
+```
+
+期待: `1 passed, 1 total`。
+
+API ルート用に node 環境を後で使うが、それは Task 3 で個別 docblock 指定する。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add package.json package-lock.json jest.config.js jest.setup.ts lib/__tests__/sanity.test.ts
+git commit -m "テスト基盤を導入: Jest + RTL + next/jest"
+```
+
+---
+
+## Task 2: `validate()` 純関数（TDD）
+
+**Files:**
+- Delete: `lib/__tests__/sanity.test.ts`
+- Create: `lib/validateContact.ts`
+- Create: `lib/__tests__/validateContact.test.ts`
+
+- [ ] **Step 1: sanity test を削除**
+
+```bash
+rm lib/__tests__/sanity.test.ts
+```
+
+- [ ] **Step 2: 失敗するテストを書く（全16ケース）**
+
+`lib/__tests__/validateContact.test.ts`:
+
+```ts
+import { validate } from '../validateContact';
+
+const valid = {
+  name: 'Ryo',
+  email: 'ryo@example.com',
+  body: 'これは10文字以上の本文。',
+  turnstileToken: 'token-xyz',
+};
+
+describe('validate()', () => {
+  it('returns empty array for fully valid input', () => {
+    expect(validate(valid)).toEqual([]);
+  });
+
+  it('returns ["name"] when name is empty', () => {
+    expect(validate({ ...valid, name: '' })).toEqual(['name']);
+  });
+
+  it('returns ["name"] when name exceeds 50 chars', () => {
+    expect(validate({ ...valid, name: 'a'.repeat(51) })).toEqual(['name']);
+  });
+
+  it('returns ["name"] when name is whitespace only', () => {
+    expect(validate({ ...valid, name: '   ' })).toEqual(['name']);
+  });
+
+  it('returns ["email"] when email is empty', () => {
+    expect(validate({ ...valid, email: '' })).toEqual(['email']);
+  });
+
+  it('returns ["email"] when email lacks @', () => {
+    expect(validate({ ...valid, email: 'invalid' })).toEqual(['email']);
+  });
+
+  it('returns ["email"] when email lacks domain dot', () => {
+    expect(validate({ ...valid, email: 'a@b' })).toEqual(['email']);
+  });
+
+  it('returns ["email"] when email is 255 chars', () => {
+    const longLocal = 'a'.repeat(245);
+    expect(validate({ ...valid, email: `${longLocal}@b.cd` })).toEqual(['email']);
+  });
+
+  it('returns ["body"] when body is empty', () => {
+    expect(validate({ ...valid, body: '' })).toEqual(['body']);
+  });
+
+  it('returns ["body"] when body is 9 chars', () => {
+    expect(validate({ ...valid, body: 'a'.repeat(9) })).toEqual(['body']);
+  });
+
+  it('returns ["body"] when body is 2001 chars', () => {
+    expect(validate({ ...valid, body: 'a'.repeat(2001) })).toEqual(['body']);
+  });
+
+  it('returns ["body"] when body trims to empty', () => {
+    expect(validate({ ...valid, body: '          ' })).toEqual(['body']);
+  });
+
+  it('returns ["turnstileToken"] when token is empty string', () => {
+    expect(validate({ ...valid, turnstileToken: '' })).toEqual(['turnstileToken']);
+  });
+
+  it('returns ["turnstileToken"] when token is undefined', () => {
+    expect(validate({ ...valid, turnstileToken: undefined })).toEqual(['turnstileToken']);
+  });
+
+  it('returns ["name","email"] when both are bad (preserved order)', () => {
+    expect(validate({ ...valid, name: '', email: 'bad' })).toEqual(['name', 'email']);
+  });
+
+  it('returns all four fields when all are bad', () => {
+    expect(validate({ name: '', email: '', body: '', turnstileToken: '' })).toEqual([
+      'name', 'email', 'body', 'turnstileToken',
+    ]);
+  });
+});
+```
+
+- [ ] **Step 3: テスト失敗を確認**
+
+```bash
+npm test -- lib/__tests__/validateContact.test.ts
+```
+
+期待: `Cannot find module '../validateContact'`（モジュール不存在）。
+
+- [ ] **Step 4: 最小実装を書く**
+
+`lib/validateContact.ts`:
+
+```ts
+export interface ContactInput {
+  name?: unknown;
+  email?: unknown;
+  body?: unknown;
+  turnstileToken?: unknown;
+}
+
+export type ContactField = 'name' | 'email' | 'body' | 'turnstileToken';
+
+export function validate(input: ContactInput): ContactField[] {
+  const errors: ContactField[] = [];
+  const name = typeof input.name === 'string' ? input.name.trim() : '';
+  const email = typeof input.email === 'string' ? input.email.trim() : '';
+  const body = typeof input.body === 'string' ? input.body.trim() : '';
+  const token = typeof input.turnstileToken === 'string' ? input.turnstileToken : '';
+
+  if (name.length < 1 || name.length > 50) errors.push('name');
+  if (
+    email.length === 0 ||
+    email.length > 254 ||
+    !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+  ) {
+    errors.push('email');
+  }
+  if (body.length < 10 || body.length > 2000) errors.push('body');
+  if (token.length === 0) errors.push('turnstileToken');
+
+  return errors;
+}
+```
+
+- [ ] **Step 5: テスト緑を確認**
+
+```bash
+npm test -- lib/__tests__/validateContact.test.ts
+```
+
+期待: `16 passed`。
+
+- [ ] **Step 6: コミット**
+
+```bash
+git add lib/validateContact.ts lib/__tests__/validateContact.test.ts
+git rm lib/__tests__/sanity.test.ts
+git commit -m "validate() 純関数を追加（TDD）"
+```
+
+---
+
+## Task 3: `pages/api/contact.ts`（TDD）
+
+**Files:**
+- Modify: `tsconfig.json`（stale 参照削除）
+- Create: `pages/api/contact.ts`
+- Create: `pages/api/__tests__/contact.test.ts`
+
+- [ ] **Step 1: tsconfig の stale 参照を削除**
+
+`tsconfig.json` の `include` から `"pages/api/contact.js"` を削除。修正後の `include`：
+
+```json
+"include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", "components/Footer.jsx"]
+```
+
+`**/*.ts` で `pages/api/contact.ts` は自動的に拾われる。
+
+- [ ] **Step 2: 失敗するテストを書く**
+
+`pages/api/__tests__/contact.test.ts`:
+
+```ts
+/**
+ * @jest-environment node
+ */
+import type { NextApiRequest, NextApiResponse } from 'next';
+import handler from '../contact';
+
+const mockSend = jest.fn();
+jest.mock('resend', () => ({
+  Resend: jest.fn(() => ({
+    emails: { send: (...args: unknown[]) => mockSend(...args) },
+  })),
+}));
+
+function makeReq(overrides: Partial<NextApiRequest> = {}): NextApiRequest {
+  return {
+    method: 'POST',
+    body: {
+      name: 'Ryo',
+      email: 'ryo@example.com',
+      body: 'これは10文字以上の本文。',
+      turnstileToken: 'tk-1',
+    },
+    headers: { 'x-forwarded-for': '203.0.113.5' },
+    ...overrides,
+  } as unknown as NextApiRequest;
+}
+
+function makeRes(): NextApiResponse & { _status: number; _body: unknown } {
+  const res: any = { _status: 200, _body: undefined };
+  res.status = (code: number) => {
+    res._status = code;
+    return res;
+  };
+  res.json = (body: unknown) => {
+    res._body = body;
+    return res;
+  };
+  return res;
+}
+
+beforeEach(() => {
+  process.env.RESEND_API_KEY = 'test-resend';
+  process.env.TURNSTILE_SECRET_KEY = 'test-secret';
+  process.env.CONTACT_TO_EMAIL = 'to@example.com';
+  mockSend.mockReset();
+  mockSend.mockResolvedValue({ id: 'mail-1' });
+  jest.spyOn(global, 'fetch').mockResolvedValue({
+    json: async () => ({ success: true }),
+  } as Response);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('POST /api/contact', () => {
+  it('returns 200 ok on full success and calls Resend with proper args', async () => {
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(200);
+    expect(res._body).toEqual({ ok: true });
+    expect(mockSend).toHaveBeenCalledTimes(1);
+    const arg = mockSend.mock.calls[0][0];
+    expect(arg.to).toBe('to@example.com');
+    expect(arg.replyTo).toBe('ryo@example.com');
+    expect(arg.subject).toContain('Ryo');
+    expect(arg.text).toContain('これは10文字以上の本文。');
+  });
+
+  it('returns 405 for GET', async () => {
+    const req = makeReq({ method: 'GET' });
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(405);
+    expect(res._body).toEqual({ ok: false, error: 'method_not_allowed' });
+  });
+
+  it('returns 400 invalid_input when name is empty (Turnstile and Resend not called)', async () => {
+    const req = makeReq({ body: { name: '', email: 'ryo@example.com', body: 'これは10文字以上の本文。', turnstileToken: 'tk' } } as Partial<NextApiRequest>);
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect(res._body).toEqual({ ok: false, error: 'invalid_input', fields: ['name'] });
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 captcha_failed when Turnstile says success:false', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      json: async () => ({ success: false }),
+    } as Response);
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect(res._body).toEqual({ ok: false, error: 'captcha_failed' });
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 captcha_failed when Turnstile fetch itself rejects', async () => {
+    (global.fetch as jest.Mock).mockRejectedValueOnce(new Error('network'));
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(400);
+    expect(res._body).toEqual({ ok: false, error: 'captcha_failed' });
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it('returns 502 send_failed when Resend throws', async () => {
+    mockSend.mockRejectedValueOnce(new Error('resend down'));
+    const req = makeReq();
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(502);
+    expect(res._body).toEqual({ ok: false, error: 'send_failed' });
+  });
+
+  it('removes \\r and \\n from name when building subject (header injection guard)', async () => {
+    const req = makeReq({
+      body: {
+        name: 'Ryo\r\nMiyata',
+        email: 'ryo@example.com',
+        body: 'これは10文字以上の本文。',
+        turnstileToken: 'tk',
+      },
+    } as Partial<NextApiRequest>);
+    const res = makeRes();
+    await handler(req, res);
+    expect(res._status).toBe(200);
+    const arg = mockSend.mock.calls[0][0];
+    expect(arg.subject).not.toMatch(/[\r\n]/);
+    expect(arg.subject).toContain('Ryo Miyata');
+  });
+});
+```
+
+- [ ] **Step 3: テスト失敗を確認**
+
+```bash
+npm test -- pages/api/__tests__/contact.test.ts
+```
+
+期待: `Cannot find module '../contact'`。
+
+- [ ] **Step 4: 最小実装を書く**
+
+`pages/api/contact.ts`:
+
+```ts
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { Resend } from 'resend';
+import { validate } from '../../lib/validateContact';
+
+type ApiResponse =
+  | { ok: true }
+  | { ok: false; error: 'method_not_allowed' }
+  | { ok: false; error: 'invalid_input'; fields: string[] }
+  | { ok: false; error: 'captcha_failed' }
+  | { ok: false; error: 'send_failed' }
+  | { ok: false; error: 'internal' };
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse<ApiResponse>,
+) {
+  if (req.method !== 'POST') {
+    return res.status(405).json({ ok: false, error: 'method_not_allowed' });
+  }
+
+  const { name, email, body, turnstileToken } = (req.body ?? {}) as Record<string, unknown>;
+
+  const fields = validate({ name, email, body, turnstileToken });
+  if (fields.length > 0) {
+    return res.status(400).json({ ok: false, error: 'invalid_input', fields });
+  }
+
+  const turnstileSecret = process.env.TURNSTILE_SECRET_KEY!;
+  const ip = (req.headers['x-forwarded-for'] as string | undefined)?.split(',')[0]?.trim() ?? '';
+  let captchaPassed = false;
+  try {
+    const verify = await fetch('https://challenges.cloudflare.com/turnstile/v0/siteverify', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        secret: turnstileSecret,
+        response: String(turnstileToken),
+        remoteip: ip,
+      }),
+    });
+    const json = (await verify.json()) as { success?: boolean };
+    captchaPassed = json.success === true;
+  } catch (e) {
+    console.warn('[contact] turnstile fetch failed', { ip });
+    captchaPassed = false;
+  }
+  if (!captchaPassed) {
+    return res.status(400).json({ ok: false, error: 'captcha_failed' });
+  }
+
+  const safeName = String(name).replace(/[\r\n]/g, ' ');
+  const safeEmail = String(email);
+  const safeBody = String(body);
+
+  try {
+    const resend = new Resend(process.env.RESEND_API_KEY!);
+    await resend.emails.send({
+      from: 'Contact Form <onboarding@resend.dev>',
+      to: process.env.CONTACT_TO_EMAIL!,
+      replyTo: safeEmail,
+      subject: `[ryo-miyata.jp] ${safeName} からのお問い合わせ`,
+      text: `From: ${safeName} <${safeEmail}>\n\n${safeBody}`,
+    });
+  } catch (e) {
+    console.error('[contact] resend failed', e);
+    return res.status(502).json({ ok: false, error: 'send_failed' });
+  }
+
+  return res.status(200).json({ ok: true });
+}
+```
+
+- [ ] **Step 5: resend SDK のインストール**
+
+```bash
+npm install resend
+```
+
+- [ ] **Step 6: テスト緑を確認**
+
+```bash
+npm test -- pages/api/__tests__/contact.test.ts
+```
+
+期待: 全ケース緑（合計7ケース）。
+
+- [ ] **Step 7: 型チェック**
+
+```bash
+npx tsc --noEmit
+```
+
+期待: エラーなし。
+
+- [ ] **Step 8: コミット**
+
+```bash
+git add pages/api/contact.ts pages/api/__tests__/contact.test.ts tsconfig.json package.json package-lock.json
+git commit -m "POST /api/contact ルートを追加（TDD、Turnstile + Resend）"
+```
+
+---
+
+## Task 4: ContactForm の idle 状態とフィールド入力
+
+**Files:**
+- Create: `components/ContactForm.jsx`
+- Create: `components/__tests__/ContactForm.test.jsx`
+
+このタスクでは ContactForm をマウントし、3フィールドが入力できて、Turnstile 未完了状態では送信ボタンが disabled になる挙動だけを実装する。送信処理（fetch）は次タスク。
+
+- [ ] **Step 1: 失敗するテストを書く**
+
+`components/__tests__/ContactForm.test.jsx`:
+
+```jsx
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import ContactForm from '../ContactForm';
+
+beforeEach(() => {
+  process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY = 'test-site-key';
+  // Turnstile グローバル stub
+  // eslint-disable-next-line no-undef
+  window.turnstile = { reset: jest.fn() };
+});
+
+describe('<ContactForm /> idle', () => {
+  it('renders all three fields and a disabled submit button', () => {
+    render(<ContactForm />);
+    expect(screen.getByLabelText(/NAME/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/EMAIL/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/MESSAGE/i)).toBeInTheDocument();
+    const button = screen.getByRole('button', { name: /send message/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('keeps button disabled when fields are filled but Turnstile token is missing', async () => {
+    const user = userEvent.setup();
+    render(<ContactForm />);
+    await user.type(screen.getByLabelText(/NAME/i), 'Ryo');
+    await user.type(screen.getByLabelText(/EMAIL/i), 'ryo@example.com');
+    await user.type(screen.getByLabelText(/MESSAGE/i), 'これは10文字以上の本文。');
+    expect(screen.getByRole('button', { name: /send message/i })).toBeDisabled();
+  });
+});
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+```bash
+npm test -- components/__tests__/ContactForm.test.jsx
+```
+
+期待: `Cannot find module '../ContactForm'`。
+
+- [ ] **Step 3: 最小実装を書く**
+
+`components/ContactForm.jsx`:
+
+```jsx
+import React, { useEffect, useState } from 'react';
+
+const inputClass =
+  'w-full border border-current bg-transparent px-2 py-1.5 text-[13px] font-jp focus:outline-none focus:bg-[var(--fg)] focus:text-[var(--bg)]';
+const labelClass = 'font-pixel text-[10px] tracking-wider opacity-70 block mb-1';
+
+const ContactForm = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [body, setBody] = useState('');
+  const [turnstileToken, setTurnstileToken] = useState('');
+
+  useEffect(() => {
+    const cb = (token) => setTurnstileToken(token);
+    window.onTurnstileSuccess = cb;
+    return () => {
+      delete window.onTurnstileSuccess;
+    };
+  }, []);
+
+  const canSubmit =
+    name.trim().length > 0 &&
+    email.trim().length > 0 &&
+    body.trim().length > 0 &&
+    turnstileToken.length > 0;
+
+  return (
+    <form>
+      <div className="mb-4">
+        <label className={labelClass} htmlFor="cf-name">NAME</label>
+        <input
+          id="cf-name"
+          type="text"
+          className={inputClass}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+      </div>
+
+      <div className="mb-4">
+        <label className={labelClass} htmlFor="cf-email">EMAIL</label>
+        <input
+          id="cf-email"
+          type="email"
+          className={inputClass}
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+      </div>
+
+      <div className="mb-4">
+        <label className={labelClass} htmlFor="cf-body">MESSAGE</label>
+        <textarea
+          id="cf-body"
+          rows={6}
+          className={inputClass}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+        />
+      </div>
+
+      <div
+        className="cf-turnstile mb-4"
+        data-sitekey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
+        data-callback="onTurnstileSuccess"
+      />
+
+      <button
+        type="submit"
+        disabled={!canSubmit}
+        className="border border-current px-3 py-1.5 font-pixel text-[11px] hover:bg-[var(--fg)] hover:text-[var(--bg)] disabled:opacity-50"
+      >
+        ▸ send message
+      </button>
+    </form>
+  );
+};
+
+export default ContactForm;
+```
+
+- [ ] **Step 4: テスト緑を確認**
+
+```bash
+npm test -- components/__tests__/ContactForm.test.jsx
+```
+
+期待: 2 passed。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add components/ContactForm.jsx components/__tests__/ContactForm.test.jsx
+git commit -m "ContactForm idle 状態を追加（TDD）"
+```
+
+---
+
+## Task 5: ContactForm の submitting 状態と送信成功
+
+**Files:**
+- Modify: `components/ContactForm.jsx`
+- Modify: `components/__tests__/ContactForm.test.jsx`
+
+- [ ] **Step 1: 追加の失敗テストを書く**
+
+`components/__tests__/ContactForm.test.jsx` の末尾に追加：
+
+```jsx
+describe('<ContactForm /> submitting and done', () => {
+  it('enables button when Turnstile callback fires with a token', async () => {
+    const user = userEvent.setup();
+    render(<ContactForm />);
+    await user.type(screen.getByLabelText(/NAME/i), 'Ryo');
+    await user.type(screen.getByLabelText(/EMAIL/i), 'ryo@example.com');
+    await user.type(screen.getByLabelText(/MESSAGE/i), 'これは10文字以上の本文。');
+    window.onTurnstileSuccess('tk-x');
+    expect(screen.getByRole('button', { name: /send message/i })).toBeEnabled();
+  });
+
+  it('shows sending... while fetch is pending and replaces form on 200', async () => {
+    let resolveFetch;
+    jest.spyOn(global, 'fetch').mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = () =>
+            resolve({
+              ok: true,
+              json: async () => ({ ok: true }),
+            });
+        }),
+    );
+
+    const user = userEvent.setup();
+    render(<ContactForm />);
+    await user.type(screen.getByLabelText(/NAME/i), 'Ryo');
+    await user.type(screen.getByLabelText(/EMAIL/i), 'ryo@example.com');
+    await user.type(screen.getByLabelText(/MESSAGE/i), 'これは10文字以上の本文。');
+    window.onTurnstileSuccess('tk-x');
+
+    await user.click(screen.getByRole('button', { name: /send message/i }));
+    expect(screen.getByRole('button', { name: /sending/i })).toBeDisabled();
+
+    resolveFetch();
+    expect(await screen.findByText(/message sent/i)).toBeInTheDocument();
+    expect(screen.getByText(/back to home/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/NAME/i)).not.toBeInTheDocument();
+  });
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+```bash
+npm test -- components/__tests__/ContactForm.test.jsx
+```
+
+期待: `submitting` 関連の2ケースが失敗。
+
+- [ ] **Step 3: ContactForm に state machine と submit ハンドラを追加**
+
+`components/ContactForm.jsx` 全体を以下に置換：
+
+```jsx
+import React, { useEffect, useState } from 'react';
+import Link from 'next/link';
+
+const inputClass =
+  'w-full border border-current bg-transparent px-2 py-1.5 text-[13px] font-jp focus:outline-none focus:bg-[var(--fg)] focus:text-[var(--bg)] disabled:opacity-50';
+const labelClass = 'font-pixel text-[10px] tracking-wider opacity-70 block mb-1';
+
+const ContactForm = () => {
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [body, setBody] = useState('');
+  const [turnstileToken, setTurnstileToken] = useState('');
+  const [status, setStatus] = useState('idle'); // idle | submitting | done
+
+  useEffect(() => {
+    window.onTurnstileSuccess = (token) => setTurnstileToken(token);
+    return () => {
+      delete window.onTurnstileSuccess;
+    };
+  }, []);
+
+  const canSubmit =
+    status === 'idle' &&
+    name.trim().length > 0 &&
+    email.trim().length > 0 &&
+    body.trim().length > 0 &&
+    turnstileToken.length > 0;
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setStatus('submitting');
+    try {
+      const res = await fetch('/api/contact', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, email, body, turnstileToken }),
+      });
+      if (res.ok) {
+        setStatus('done');
+      } else {
+        setStatus('idle');
+      }
+    } catch {
+      setStatus('idle');
+    }
+  };
+
+  if (status === 'done') {
+    return (
+      <div>
+        <p className="font-pixel text-[16px]">▸ message sent.</p>
+        <p className="font-jp text-[12px] mt-3 leading-[1.7] opacity-80">
+          ありがとうございます。<br />
+          通常 1〜3 営業日以内にお返事します。
+        </p>
+        <Link
+          href="/"
+          className="font-pixel text-[11px] underline mt-6 inline-block"
+        >
+          ▸ back to home
+        </Link>
+      </div>
+    );
+  }
+
+  const fieldsDisabled = status === 'submitting';
+
+  return (
+    <form onSubmit={handleSubmit}>
+      <div className="mb-4">
+        <label className={labelClass} htmlFor="cf-name">NAME</label>
+        <input
+          id="cf-name"
+          type="text"
+          className={inputClass}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          disabled={fieldsDisabled}
+        />
+      </div>
+
+      <div className="mb-4">
+        <label className={labelClass} htmlFor="cf-email">EMAIL</label>
+        <input
+          id="cf-email"
+          type="email"
+          className={inputClass}
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          disabled={fieldsDisabled}
+        />
+      </div>
+
+      <div className="mb-4">
+        <label className={labelClass} htmlFor="cf-body">MESSAGE</label>
+        <textarea
+          id="cf-body"
+          rows={6}
+          className={inputClass}
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          disabled={fieldsDisabled}
+        />
+      </div>
+
+      <div
+        className="cf-turnstile mb-4"
+        data-sitekey={process.env.NEXT_PUBLIC_TURNSTILE_SITE_KEY}
+        data-callback="onTurnstileSuccess"
+      />
+
+      <button
+        type="submit"
+        disabled={!canSubmit}
+        className="border border-current px-3 py-1.5 font-pixel text-[11px] hover:bg-[var(--fg)] hover:text-[var(--bg)] disabled:opacity-50"
+      >
+        {status === 'submitting' ? '▸ sending...' : '▸ send message'}
+      </button>
+    </form>
+  );
+};
+
+export default ContactForm;
+```
+
+- [ ] **Step 4: テスト緑を確認**
+
+```bash
+npm test -- components/__tests__/ContactForm.test.jsx
+```
+
+期待: idle 2 + submitting/done 2 = 4 passed。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add components/ContactForm.jsx components/__tests__/ContactForm.test.jsx
+git commit -m "ContactForm submitting / done 状態を追加（TDD）"
+```
+
+---
+
+## Task 6: ContactForm のエラー表示（バナー + Turnstile リセット）
+
+**Files:**
+- Modify: `components/ContactForm.jsx`
+- Modify: `components/__tests__/ContactForm.test.jsx`
+
+- [ ] **Step 1: 追加テストを書く**
+
+`components/__tests__/ContactForm.test.jsx` 末尾に追加：
+
+```jsx
+describe('<ContactForm /> error banner', () => {
+  it('shows generic banner and resets Turnstile when API returns 502 send_failed', async () => {
+    const resetMock = jest.fn();
+    window.turnstile = { reset: resetMock };
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 502,
+      json: async () => ({ ok: false, error: 'send_failed' }),
+    });
+
+    const user = userEvent.setup();
+    render(<ContactForm />);
+    await user.type(screen.getByLabelText(/NAME/i), 'Ryo');
+    await user.type(screen.getByLabelText(/EMAIL/i), 'ryo@example.com');
+    await user.type(screen.getByLabelText(/MESSAGE/i), 'これは10文字以上の本文。');
+    window.onTurnstileSuccess('tk-x');
+    await user.click(screen.getByRole('button', { name: /send message/i }));
+
+    expect(await screen.findByText(/送信に失敗しました/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/NAME/i)).toBeInTheDocument(); // form still present
+    expect(resetMock).toHaveBeenCalled();
+  });
+
+  it('shows captcha-specific banner when API returns 400 captcha_failed', async () => {
+    window.turnstile = { reset: jest.fn() };
+    jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: async () => ({ ok: false, error: 'captcha_failed' }),
+    });
+
+    const user = userEvent.setup();
+    render(<ContactForm />);
+    await user.type(screen.getByLabelText(/NAME/i), 'Ryo');
+    await user.type(screen.getByLabelText(/EMAIL/i), 'ryo@example.com');
+    await user.type(screen.getByLabelText(/MESSAGE/i), 'これは10文字以上の本文。');
+    window.onTurnstileSuccess('tk-x');
+    await user.click(screen.getByRole('button', { name: /send message/i }));
+
+    expect(await screen.findByText(/ロボット判定に失敗/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+```bash
+npm test -- components/__tests__/ContactForm.test.jsx
+```
+
+期待: error banner の2ケースが失敗。
+
+- [ ] **Step 3: バナー表示と Turnstile リセットを実装**
+
+`components/ContactForm.jsx` の `handleSubmit` を以下に差し替え、`status` を `idle | submitting | done` から `idle | submitting | done` のままで、別途 `errorCode` state を導入する：
+
+```jsx
+// state 追加
+const [errorCode, setErrorCode] = useState(null); // null | 'captcha_failed' | 'send_failed' | 'network'
+
+// handleSubmit 差し替え
+const handleSubmit = async (e) => {
+  e.preventDefault();
+  if (!canSubmit) return;
+  setStatus('submitting');
+  setErrorCode(null);
+  try {
+    const res = await fetch('/api/contact', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, email, body, turnstileToken }),
+    });
+    if (res.ok) {
+      setStatus('done');
+      return;
+    }
+    const data = await res.json().catch(() => ({}));
+    const code = data?.error === 'captcha_failed' ? 'captcha_failed' : 'send_failed';
+    setErrorCode(code);
+    setStatus('idle');
+    if (typeof window !== 'undefined' && window.turnstile?.reset) {
+      window.turnstile.reset();
+    }
+    setTurnstileToken('');
+  } catch {
+    setErrorCode('network');
+    setStatus('idle');
+    if (typeof window !== 'undefined' && window.turnstile?.reset) {
+      window.turnstile.reset();
+    }
+    setTurnstileToken('');
+  }
+};
+```
+
+そして `<form>` の直前に以下のバナーを追加：
+
+```jsx
+{errorCode && (
+  <div className="border border-current p-2 mb-3 font-pixel text-[11px]">
+    {errorCode === 'captcha_failed'
+      ? '▸ ロボット判定に失敗しました。再度お試しください'
+      : '▸ 送信に失敗しました。少し時間をおいて再度お試しください'}
+  </div>
+)}
+```
+
+- [ ] **Step 4: テスト緑を確認**
+
+```bash
+npm test -- components/__tests__/ContactForm.test.jsx
+```
+
+期待: idle 2 + submitting/done 2 + error 2 = 6 passed。
+
+- [ ] **Step 5: コミット**
+
+```bash
+git add components/ContactForm.jsx components/__tests__/ContactForm.test.jsx
+git commit -m "ContactForm エラーバナーと Turnstile リセットを追加（TDD）"
+```
+
+---
+
+## Task 7: ContactForm の inline クライアント側バリデーション
+
+**Files:**
+- Modify: `components/ContactForm.jsx`
+- Modify: `components/__tests__/ContactForm.test.jsx`
+
+- [ ] **Step 1: 追加テストを書く**
+
+`components/__tests__/ContactForm.test.jsx` 末尾に追加：
+
+```jsx
+describe('<ContactForm /> inline validation', () => {
+  it('shows inline email error and does not call fetch', async () => {
+    const fetchSpy = jest.spyOn(global, 'fetch');
+    const user = userEvent.setup();
+    render(<ContactForm />);
+    await user.type(screen.getByLabelText(/NAME/i), 'Ryo');
+    await user.type(screen.getByLabelText(/EMAIL/i), 'abc'); // invalid
+    await user.type(screen.getByLabelText(/MESSAGE/i), 'これは10文字以上の本文。');
+    window.onTurnstileSuccess('tk-x');
+    await user.click(screen.getByRole('button', { name: /send message/i }));
+    expect(await screen.findByText(/メールアドレスの形式/)).toBeInTheDocument();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('shows inline body length error', async () => {
+    const user = userEvent.setup();
+    render(<ContactForm />);
+    await user.type(screen.getByLabelText(/NAME/i), 'Ryo');
+    await user.type(screen.getByLabelText(/EMAIL/i), 'ryo@example.com');
+    await user.type(screen.getByLabelText(/MESSAGE/i), 'short');
+    window.onTurnstileSuccess('tk-x');
+    await user.click(screen.getByRole('button', { name: /send message/i }));
+    expect(await screen.findByText(/10〜2000 文字/)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: テスト失敗を確認**
+
+```bash
+npm test -- components/__tests__/ContactForm.test.jsx
+```
+
+期待: inline 関連の2ケースが失敗。
+
+- [ ] **Step 3: validate を import し inline エラーを描画**
+
+`components/ContactForm.jsx` の冒頭に追加：
+
+```jsx
+import { validate } from '../lib/validateContact';
+```
+
+state 追加：
+
+```jsx
+const [fieldErrors, setFieldErrors] = useState([]);
+```
+
+`handleSubmit` 先頭に追加（`if (!canSubmit) return;` の **直後**）：
+
+```jsx
+const errs = validate({ name, email, body, turnstileToken });
+if (errs.length > 0) {
+  setFieldErrors(errs);
+  return;
+}
+setFieldErrors([]);
+```
+
+各フィールドの `<div className="mb-4">` の input/textarea の **直下** に inline エラーを追加：
+
+```jsx
+{fieldErrors.includes('name') && (
+  <p className="font-pixel text-[10px] mt-1">▸ お名前を入力してください（50字以内）</p>
+)}
+```
+
+```jsx
+{fieldErrors.includes('email') && (
+  <p className="font-pixel text-[10px] mt-1">▸ メールアドレスの形式が正しくありません</p>
+)}
+```
+
+```jsx
+{fieldErrors.includes('body') && (
+  <p className="font-pixel text-[10px] mt-1">▸ 本文は 10〜2000 文字で入力してください</p>
+)}
+```
+
+- [ ] **Step 4: テスト緑を確認**
+
+```bash
+npm test -- components/__tests__/ContactForm.test.jsx
+```
+
+期待: 全8ケース緑。
+
+- [ ] **Step 5: 全テスト一括実行**
+
+```bash
+npm test
+```
+
+期待: validate 16 + API 7 + ContactForm 8 = 31 passed。
+
+- [ ] **Step 6: 型チェック**
+
+```bash
+npx tsc --noEmit
+```
+
+期待: エラーなし。
+
+- [ ] **Step 7: コミット**
+
+```bash
+git add components/ContactForm.jsx components/__tests__/ContactForm.test.jsx
+git commit -m "ContactForm inline バリデーションエラーを追加（TDD）"
+```
+
+---
+
+## Task 8: `/contact` ページと Turnstile script 注入
+
+**Files:**
+- Create: `pages/contact.tsx`
+
+- [ ] **Step 1: ページを作成**
+
+`pages/contact.tsx`:
+
+```tsx
+import type { NextPage } from 'next';
+import Head from 'next/head';
+import Script from 'next/script';
+import { SectionHeading } from '../components/ui';
+import ContactForm from '../components/ContactForm';
+
+const Contact: NextPage = () => (
+  <div>
+    <Head>
+      <title>Ryo Miyata — Contact</title>
+    </Head>
+    <Script
+      src="https://challenges.cloudflare.com/turnstile/v0/api.js"
+      async
+      defer
+    />
+    <section className="px-5 py-5 border-t border-current">
+      <SectionHeading>contact</SectionHeading>
+      <p className="font-jp text-[13px] leading-[1.8] mb-5">
+        ご連絡ありがとうございます。お仕事のご相談、雑談、なんでもどうぞ。<br />
+        通常 1〜3 営業日以内にお返事します。
+      </p>
+      <ContactForm />
+    </section>
+  </div>
+);
+
+export default Contact;
+```
+
+- [ ] **Step 2: 開発サーバーで起動確認**
+
+```bash
+npm run dev
+```
+
+ブラウザで `http://localhost:3000/contact` を開く。期待：
+
+- ヘッダ・フッタが表示される
+- "// contact" 見出し、説明文、フォーム3項目が表示される
+- Turnstile widget が読み込まれ、操作可能
+- 全項目入力 + Turnstile 完了で送信ボタンが押せる
+- 押下 → gmail にメール到着 → 「返信」で送信者アドレス宛になる
+- 送信後フォームが完了画面に置き換わり、`▸ back to home` でトップに戻る
+
+サーバーを停止（Ctrl+C）。
+
+- [ ] **Step 3: 型チェックとテスト**
+
+```bash
+npx tsc --noEmit && npm test
+```
+
+期待: エラーなし、全テスト緑。
+
+- [ ] **Step 4: コミット**
+
+```bash
+git add pages/contact.tsx
+git commit -m "/contact ページを追加（Turnstile script 注入 + ContactForm マウント）"
+```
+
+---
+
+## Task 9: トップページのリンクを差し替え
+
+**Files:**
+- Modify: `pages/index.tsx:105-116`
+
+- [ ] **Step 1: contact セクションを書き換え**
+
+現在の `pages/index.tsx:105-116`：
+
+```jsx
+{/* Contact */}
+<section className="px-5 py-5 border-t border-current">
+  <SectionHeading>contact</SectionHeading>
+  <a
+    href="https://docs.google.com/forms/d/e/1FAIpQLSfp__zqzghA2tSgqdr7WubZP0hqpxhw-5YJRMDj0RkdEcITlw/viewform?usp=publish-editor"
+    target="_blank"
+    rel="noopener noreferrer"
+    className="font-pixel text-[12px] underline"
+  >
+    ▸ open contact form (google)
+  </a>
+</section>
+```
+
+を以下に置換：
+
+```jsx
+{/* Contact */}
+<section className="px-5 py-5 border-t border-current">
+  <SectionHeading>contact</SectionHeading>
+  <Link href="/contact" className="font-pixel text-[12px] underline">
+    ▸ open contact form
+  </Link>
+</section>
+```
+
+`Link` は `pages/index.tsx:2` で既に import 済み。
+
+- [ ] **Step 2: 開発サーバーで動作確認**
+
+```bash
+npm run dev
+```
+
+トップ → contact セクション → リンクをクリック → `/contact` へ遷移できる。サーバー停止（Ctrl+C）。
+
+- [ ] **Step 3: コミット**
+
+```bash
+git add pages/index.tsx
+git commit -m "トップページの contact リンクを Google Forms から /contact に差し替え"
+```
+
+---
+
+## Task 10: 仕上げと最終検証
+
+**Files:** なし（検証のみ）
+
+- [ ] **Step 1: 全テストとビルド検証**
+
+```bash
+npm test && npx tsc --noEmit && npm run build
+```
+
+期待：
+
+- Jest: 全テスト緑（合計 31 程度）
+- TS: エラーなし
+- Next ビルド: エラーなし、`.next/` 生成
+
+- [ ] **Step 2: 本番ビルドで動作確認**
+
+```bash
+npm start
+```
+
+別ターミナルで：
+
+```bash
+curl -i http://localhost:3000/contact
+```
+
+期待: `HTTP/1.1 200 OK`。`/contact` の HTML が返る。
+
+サーバー停止。
+
+- [ ] **Step 3: スパム対策の負テスト（手動）**
+
+`curl` で **Turnstile token を空** にして直接 API を叩く：
+
+```bash
+curl -i -X POST http://localhost:3000/api/contact \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Bot","email":"bot@example.com","body":"これは10文字以上の本文。","turnstileToken":""}'
+```
+
+期待: `400` で `{"ok":false,"error":"invalid_input","fields":["turnstileToken"]}`。
+
+偽 token を渡したケース：
+
+```bash
+curl -i -X POST http://localhost:3000/api/contact \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Bot","email":"bot@example.com","body":"これは10文字以上の本文。","turnstileToken":"fake-token"}'
+```
+
+期待: `400` で `{"ok":false,"error":"captcha_failed"}`。
+
+- [ ] **Step 4: 受け入れ条件のチェック**
+
+`docs/superpowers/specs/2026-05-01-contact-form-design.md` の「受け入れ条件」セクションを開き、各項目を1つずつチェック。すべて緑なら完了。
+
+- [ ] **Step 5: 最終コミット（必要なら）**
+
+ここまでで未コミット変更がなければスキップ。何かあれば：
+
+```bash
+git add -A
+git commit -m "お問い合わせフォーム: 最終調整"
+```
+
+- [ ] **Step 6: 完了報告**
+
+実装完了をユーザーに報告。次の議論候補：
+
+- 独自ドメインからの送信（`onboarding@resend.dev` → `contact@ryo-miyata.jp` 等）
+- working tree に残っている削除待ちファイル（`docs/SPEC.md` 等）の整理

--- a/docs/superpowers/specs/2026-05-01-contact-form-design.md
+++ b/docs/superpowers/specs/2026-05-01-contact-form-design.md
@@ -3,6 +3,7 @@
 - 作成日: 2026-05-01
 - ステータス: 設計確定（実装計画作成前）
 - 関連: 既存 `pages/index.tsx:108-115` の Google Forms 外部リンク廃止
+- 実装方針: テスト駆動開発（TDD / Red→Green→Refactor）
 
 ## 背景・目的
 
@@ -78,11 +79,24 @@
 
 - `pages/index.tsx`: contact セクションのリンクを Google Forms から `/contact` に置換、`(google)` 文言削除
 
-### 新規依存
+### 新規依存（プロダクション）
 
 - `resend`（公式 SDK）
 
 Cloudflare Turnstile は素の `<script>` 注入で組む。`@marsidev/react-turnstile` 等のラッパー依存は採用しない（最近の未使用パッケージ削除方針と整合）。
+
+### 新規依存（開発・テスト）
+
+プロジェクト初のテスト基盤を導入する：
+
+- `jest`
+- `jest-environment-jsdom`
+- `@testing-library/react`
+- `@testing-library/jest-dom`
+- `@testing-library/user-event`
+- `@types/jest`
+
+Next.js 13 公式の `next/jest` プリセットを使用し、Babel 設定を SWC ベースで自動構成する。
 
 ### 新規環境変数（`.env`）
 
@@ -293,6 +307,129 @@ inline はフィールド単位、バナーは全体スコープのエラー、�
 - `subject` のユーザー名は `\r`/`\n` を空白に置換してヘッダインジェクション防止
 - `TURNSTILE_SECRET_KEY` と `RESEND_API_KEY` は サーバー側のみで参照、クライアントへ露出させない
 
+## テスト戦略（TDD）
+
+### 基本方針
+
+すべての新規コードは **Red → Green → Refactor** サイクルで実装する：
+
+1. **Red**: 期待挙動を表すテストを先に書き、失敗することを確認
+2. **Green**: テストが通る最小限の実装を書く
+3. **Refactor**: テストが緑のまま、コードを整える
+
+各レイヤーごとに独立したテストファイルを持ち、外部 I/O（Resend、Turnstile siteverify）は **必ずモック** する。本物の API を叩くテストは作らない（無料枠消費と再現性破壊のため）。
+
+### フレームワーク構成
+
+- ランナー: **Jest**
+- React テスト: **`@testing-library/react`** + **`@testing-library/user-event`**
+- マッチャ拡張: **`@testing-library/jest-dom`**
+- 環境: **`jest-environment-jsdom`**（コンポーネントテスト用）/ **`node`**（API テスト用）
+- Next.js 統合: **`next/jest`** プリセット（SWC 経由で TS/JSX を自動変換）
+
+### 設定ファイル
+
+新規作成：
+
+- `jest.config.js` — `next/jest` プリセットを呼び出し、`testEnvironment: 'jsdom'` をデフォルト、API テストは `@jest-environment node` の docblock で個別指定
+- `jest.setup.ts` — `@testing-library/jest-dom` を import
+- `package.json` の `scripts` に `"test": "jest"`、`"test:watch": "jest --watch"` を追加
+
+### テスト対象とテストファイルの対応
+
+| 対象 | テストファイル | 環境 | 種別 |
+|---|---|---|---|
+| `validate()`（純関数） | `pages/api/__tests__/validate.test.ts` | node | unit |
+| `POST /api/contact` | `pages/api/__tests__/contact.test.ts` | node | integration（モック） |
+| `<ContactForm />` | `components/__tests__/ContactForm.test.tsx` | jsdom | component |
+
+`pages/contact.tsx` 自体は ContactForm をマウントするだけの薄いラッパーなのでテスト対象外。
+
+### `validate()` のテストケース（全16ケース想定）
+
+| # | 入力 | 期待される errors |
+|---|---|---|
+| 1 | 全項目正常 | `[]` |
+| 2 | name が空 | `['name']` |
+| 3 | name が 51 文字 | `['name']` |
+| 4 | name が前後空白のみ | `['name']` |
+| 5 | email が空 | `['email']` |
+| 6 | email に `@` がない | `['email']` |
+| 7 | email にドメイン部の `.` がない | `['email']` |
+| 8 | email が 255 文字 | `['email']` |
+| 9 | body が空 | `['body']` |
+| 10 | body が 9 文字 | `['body']` |
+| 11 | body が 2001 文字 | `['body']` |
+| 12 | body が前後空白で実質空 | `['body']` |
+| 13 | turnstileToken が空文字 | `['turnstileToken']` |
+| 14 | turnstileToken が undefined | `['turnstileToken']` |
+| 15 | name と email が同時に不正 | `['name', 'email']`（順序保証） |
+| 16 | 全項目が不正 | `['name', 'email', 'body', 'turnstileToken']` |
+
+### `/api/contact` のテストケース
+
+`global.fetch` を Jest の `jest.spyOn` でモックし、Resend SDK は `jest.mock('resend', () => ...)` で差し替え：
+
+| # | シナリオ | モック設定 | 期待 |
+|---|---|---|---|
+| 1 | 正常系 | siteverify=success、resend.emails.send=resolve | `200 { ok: true }`、`emails.send` が正しい引数で呼ばれる |
+| 2 | GET メソッド | — | `405 method_not_allowed` |
+| 3 | バリデーション失敗（name 空） | — | `400 invalid_input fields=['name']`、Turnstile/Resend は呼ばれない |
+| 4 | Turnstile 失敗 | siteverify=`{success:false}` | `400 captcha_failed`、Resend は呼ばれない |
+| 5 | Turnstile API 自体が落ちる | siteverify=reject | `400 captcha_failed`（フェイルクローズ） |
+| 6 | Resend が throw | siteverify=success、resend=reject | `502 send_failed` |
+| 7 | subject へのヘッダインジェクション試行 | name に `\n` 含む | resend に渡る subject に `\n` がない |
+| 8 | replyTo にユーザーメールが入る | 正常系 | `emails.send` の呼び出し引数に `replyTo: <input>` |
+
+### `<ContactForm />` のテストケース
+
+`fetch` をモックして API を差し替え。Turnstile widget は `data-callback` グローバル関数を直接呼び出してトークン取得をシミュレート：
+
+| # | シナリオ | 操作 | 期待 |
+|---|---|---|---|
+| 1 | 初期表示 | — | フォームが表示、送信ボタンは disabled、エラーバナーなし |
+| 2 | 必須項目を埋める | type into name/email/body | 送信ボタンは依然 disabled（token 未取得） |
+| 3 | Turnstile token 取得 | callback 呼び出し | 送信ボタンが enabled |
+| 4 | 送信中表示 | submit クリック → fetch 未解決 | ボタン文言が `▸ sending...`、フォーム disabled |
+| 5 | 送信成功 | fetch=200 解決 | フォームが消え、`▸ message sent.` と back to home リンク表示 |
+| 6 | 送信失敗（send_failed） | fetch=502 | フォーム残存、上部に「送信に失敗しました…」バナー、Turnstile リセット呼び出し |
+| 7 | 送信失敗（captcha_failed） | fetch=`400 captcha_failed` | 上部に「ロボット判定に失敗…」バナー、Turnstile リセット |
+| 8 | inline エラー（client validation） | email に `abc` 入れて submit | inline で「メールアドレスの形式が正しくありません」、API は呼ばれない |
+| 9 | name の長さ超過 | 51文字の name | inline 「お名前を入力してください（50字以内）」 |
+| 10 | body の最小 | 9文字の body | inline 「本文は 10〜2000 文字…」 |
+
+### モック方針
+
+| 対象 | モック方法 |
+|---|---|
+| `global.fetch` | `jest.spyOn(global, 'fetch').mockResolvedValue(...)` |
+| `resend` SDK | ファイル冒頭で `jest.mock('resend', () => ({ Resend: jest.fn(() => ({ emails: { send: jest.fn() } })) }))` |
+| `next/router` | コンポーネントテストでは `<Link>` のクリックを検証する程度。完了画面の back to home は `<Link href="/">` が描画されていれば OK（実際の遷移はテストしない） |
+| Turnstile `<script>` | テスト環境では未読み込み。`window.turnstile` を `{ reset: jest.fn() }` で stub し、`data-callback` 用のグローバル関数を直接呼ぶ |
+| 環境変数 | `process.env.RESEND_API_KEY` 等を `beforeEach` でセット、`afterEach` で復元 |
+
+### 実装順序（TDD ループの並び）
+
+各ステップで「テスト先 → 実装 → 緑」を1セット：
+
+1. テスト基盤の導入（jest 関連 devDeps + 設定ファイル + 動作確認の sanity test）
+2. `validate()` 関数（純関数 → 最も TDD と相性が良い）
+3. `pages/api/contact.ts`（validate を再利用、Turnstile/Resend モック）
+4. `<ContactForm />` の idle 状態とフィールド入力
+5. `<ContactForm />` の submitting 状態
+6. `<ContactForm />` の done 状態
+7. `<ContactForm />` のエラーバナー / inline エラー
+8. `pages/contact.tsx` の薄いラッパー（テスト不要、目視確認）
+9. `pages/index.tsx` のリンク差し替え（既存テストなし、目視確認）
+
+### CI 連携
+
+本リポジトリは現在 CI 未設定。本 spec のスコープでは CI 追加を行わない（YAGNI）。ローカルで `npm test` がパスすれば実装完了とみなす。CI 化は別 spec で扱う。
+
+### カバレッジ目標
+
+数値目標は設けない。代わりに「上記テストケース表を全て満たすこと」を完了条件とする。カバレッジツールは導入しない。
+
 ## 受け入れ条件
 
 - [ ] `/contact` で名前・メール・本文・Turnstile を満たして送信すると、`miyata09x0084@gmail.com` に到着する
@@ -305,3 +442,5 @@ inline はフィールド単位、バナーは全体スコープのエラー、�
 - [ ] トップページの contact リンクが `/contact` を指している（Google Forms URL 削除）
 - [ ] `(google)` 文言が削除されている
 - [ ] 1-bit Mac モノクロ・pixel フォント・border invert ホバーが他ページと整合
+- [ ] `npm test` がパス、テスト戦略セクションに列挙したケースが全て緑
+- [ ] 各実装ステップが TDD（Red → Green → Refactor）で進められた

--- a/docs/superpowers/specs/2026-05-01-contact-form-design.md
+++ b/docs/superpowers/specs/2026-05-01-contact-form-design.md
@@ -1,0 +1,307 @@
+# お問い合わせフォーム設計書
+
+- 作成日: 2026-05-01
+- ステータス: 設計確定（実装計画作成前）
+- 関連: 既存 `pages/index.tsx:108-115` の Google Forms 外部リンク廃止
+
+## 背景・目的
+
+現状、トップページ末尾の "contact" セクションは Google Forms への外部リンク1本のみ。これを廃止し、サイト内で完結する自前のお問い合わせフォームに置き換える。
+
+主な動機：
+
+- サイト内完結による UX/世界観の一貫性（1-bit Mac モノクロデザイン）
+- 自分の管理下にデータを置く
+
+## スコープ
+
+### やること
+
+- `/contact` 専用ページ新設
+- メール送信（Resend）連携
+- Cloudflare Turnstile によるスパム対策
+- トップページからの導線リンク変更
+
+### やらないこと（YAGNI）
+
+- 履歴の永続化（Hygraph 保存等）
+- 自動返信メール
+- 多言語化（日本語のみ）
+- API 側のレート制限（Turnstile で代替）
+- CSRF/Origin チェック（認証なしフォームのため）
+- 独自ドメインからの送信（`onboarding@resend.dev` から開始）
+
+## 要件サマリー
+
+| 項目 | 決定 |
+|---|---|
+| 送信先 | Resend → `miyata09x0084@gmail.com` |
+| 配置 | `/contact` 専用ページ。トップは導線リンクのみ |
+| 入力項目 | 名前 / メール / 本文（3項目） |
+| スパム対策 | Cloudflare Turnstile |
+| 完了UX | 同一ページ内でフォーム→完了メッセージ差し替え |
+| 言語 | ラベルは pixel 大文字英語、説明文は日本語 |
+
+## アーキテクチャ
+
+```
+[ /contact ページ (pages/contact.tsx) ]
+        │
+        │  ① ユーザー入力 + Turnstile widget でトークン取得
+        ▼
+[ ContactForm コンポーネント (components/ContactForm.jsx) ]
+        │
+        │  ② POST /api/contact { name, email, body, turnstileToken }
+        ▼
+[ API ルート (pages/api/contact.ts) ]
+        │
+        │  ③ サーバー側で Turnstile 検証
+        │     POST https://challenges.cloudflare.com/turnstile/v0/siteverify
+        ▼
+        │  ④ 通過したら Resend で送信
+        │     to: miyata09x0084@gmail.com
+        │     reply-to: ユーザー入力のメール
+        │     from: onboarding@resend.dev
+        ▼
+[ Resend ] → gmail 受信
+```
+
+### 新規ファイル
+
+| ファイル | 責務 |
+|---|---|
+| `pages/contact.tsx` | ページ枠 + Head + 説明文 + `<ContactForm />` の配置 |
+| `pages/api/contact.ts` | API ルート（`pages/api/` 自体も新規作成） |
+| `components/ContactForm.jsx` | state（idle/submitting/done/error）・送信処理・Turnstile 連携・フォーム描画 |
+
+### 変更ファイル
+
+- `pages/index.tsx`: contact セクションのリンクを Google Forms から `/contact` に置換、`(google)` 文言削除
+
+### 新規依存
+
+- `resend`（公式 SDK）
+
+Cloudflare Turnstile は素の `<script>` 注入で組む。`@marsidev/react-turnstile` 等のラッパー依存は採用しない（最近の未使用パッケージ削除方針と整合）。
+
+### 新規環境変数（`.env`）
+
+```
+RESEND_API_KEY=
+TURNSTILE_SITE_KEY=
+TURNSTILE_SECRET_KEY=
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+CONTACT_TO_EMAIL=miyata09x0084@gmail.com
+```
+
+`TURNSTILE_SITE_KEY` と `NEXT_PUBLIC_TURNSTILE_SITE_KEY` は同値。後者だけがクライアントに露出する。
+
+事前準備（実装前）:
+
+- Cloudflare アカウントで Turnstile サイトキー/シークレットキーを発行
+- Resend アカウントで API キーを発行
+
+## 画面・UI 設計
+
+### `/contact` ページ構造
+
+- 既存 `Layout`（720px 枠）の中に配置
+- `<section className="px-5 py-5">` で他ページと同じ枠取り
+- `<SectionHeading>contact</SectionHeading>` を冒頭に配置
+- 説明文（日本語2行）
+- `<ContactForm />` を配置
+
+### 状態遷移
+
+```
+idle ─[submit押下]─→ submitting ─[200]─→ done
+                          │
+                          └─[error]──→ idle (上部にエラー表示)
+```
+
+| 状態 | 表示 |
+|---|---|
+| `idle` | フォーム表示。ボタン: `▸ send message` |
+| `submitting` | フォーム disabled。ボタン: `▸ sending...` |
+| `done` | フォーム消滅。`▸ message sent.` + 日本語サブ文 + `▸ back to home` リンク |
+| `error` | `idle` 復帰。フォーム上部にエラーバナー |
+
+### 1-bit Mac スタイル適用
+
+| 要素 | クラス |
+|---|---|
+| ラベル | `font-pixel text-[10px] tracking-wider opacity-70`（NAME/EMAIL/MESSAGE） |
+| input/textarea | `w-full border border-current bg-transparent px-2 py-1.5 text-[13px] font-jp focus:outline-none focus:bg-[var(--fg)] focus:text-[var(--bg)]` |
+| 送信ボタン | `border border-current px-3 py-1.5 font-pixel text-[11px] hover:bg-[var(--fg)] hover:text-[var(--bg)] disabled:opacity-50` |
+| 完了メッセージ見出し | `font-pixel text-[16px]` |
+| 完了メッセージ本文 | `font-jp text-[12px] mt-3 leading-[1.7] opacity-80` |
+| エラーバナー | `border border-current p-2 mb-3 font-pixel text-[11px]` |
+
+### トップページの差し替え
+
+`pages/index.tsx:108-115` を以下に置換：
+
+```jsx
+{/* Contact */}
+<section className="px-5 py-5 border-t border-current">
+  <SectionHeading>contact</SectionHeading>
+  <Link href="/contact" className="font-pixel text-[12px] underline">
+    ▸ open contact form
+  </Link>
+</section>
+```
+
+## API 設計
+
+### エンドポイント
+
+- `POST /api/contact`
+- Runtime: Node.js（デフォルト）
+- Content-Type: `application/json`
+
+### リクエスト
+
+```ts
+{
+  name: string;            // 1-50 文字（trim 後）
+  email: string;           // 簡易形式チェック、最大 254 文字
+  body: string;            // 10-2000 文字（trim 後）
+  turnstileToken: string;  // Cloudflare Turnstile からの token
+}
+```
+
+### レスポンス
+
+| ケース | HTTP | body |
+|---|---|---|
+| 成功 | 200 | `{ ok: true }` |
+| バリデーション失敗 | 400 | `{ ok: false, error: "invalid_input", fields: [...] }` |
+| Turnstile 失敗 | 400 | `{ ok: false, error: "captcha_failed" }` |
+| Method 違い | 405 | `{ ok: false, error: "method_not_allowed" }` |
+| Resend エラー | 502 | `{ ok: false, error: "send_failed" }` |
+| 想定外 | 500 | `{ ok: false, error: "internal" }` |
+
+### 処理フロー
+
+1. `req.method !== 'POST'` → 405
+2. `req.body` から取り出し
+3. `validate()` で項目検査 → 不合格項目があれば 400
+4. Turnstile `siteverify` 呼び出し → `success: false` なら 400
+5. Resend `emails.send()` → 失敗なら 502
+6. 200 を返す
+
+### Resend 送信内容
+
+```ts
+{
+  from: 'Contact Form <onboarding@resend.dev>',
+  to: process.env.CONTACT_TO_EMAIL!,
+  replyTo: email,
+  subject: `[ryo-miyata.jp] ${name.replace(/[\r\n]/g, ' ')} からのお問い合わせ`,
+  text: `From: ${name} <${email}>\n\n${body}`,
+}
+```
+
+`subject` のユーザー名は改行を空白に置換してヘッダインジェクションを防ぐ。本文は plain text のみ（HTML メールは作らない → XSS 不要）。
+
+### ログ方針
+
+- 成功: ログなし
+- Turnstile 失敗: `console.warn('[contact] turnstile failed', { ip })`（本文は出さない）
+- Resend 失敗: `console.error('[contact] resend failed', e)`（stack のみ）
+
+## バリデーション
+
+クライアント・サーバー双方で同じルールを適用。クライアントは UX 即時フィードバック用、サーバーが信頼の最終線。
+
+| 項目 | ルール |
+|---|---|
+| `name` | 必須・trim 後 1-50 文字 |
+| `email` | 必須・`/^[^\s@]+@[^\s@]+\.[^\s@]+$/`・最大 254 文字 |
+| `body` | 必須・trim 後 10-2000 文字 |
+| `turnstileToken` | 必須・空文字不可 |
+
+サーバー側 `validate()`:
+
+```ts
+function validate(input: {
+  name?: unknown; email?: unknown; body?: unknown; turnstileToken?: unknown;
+}): string[] {
+  const errors: string[] = [];
+  const name = typeof input.name === 'string' ? input.name.trim() : '';
+  const email = typeof input.email === 'string' ? input.email.trim() : '';
+  const body = typeof input.body === 'string' ? input.body.trim() : '';
+  const token = typeof input.turnstileToken === 'string' ? input.turnstileToken : '';
+
+  if (name.length < 1 || name.length > 50) errors.push('name');
+  if (email.length === 0 || email.length > 254 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email))
+    errors.push('email');
+  if (body.length < 10 || body.length > 2000) errors.push('body');
+  if (token.length === 0) errors.push('turnstileToken');
+
+  return errors;
+}
+```
+
+## エラー表示（クライアント）
+
+| 失敗種別 | 表示 |
+|---|---|
+| `name` | name ラベル下に inline `▸ お名前を入力してください（50字以内）` |
+| `email` | email ラベル下に inline `▸ メールアドレスの形式が正しくありません` |
+| `body` | body ラベル下に inline `▸ 本文は 10〜2000 文字で入力してください` |
+| `turnstileToken` 未取得 | フォーム上部バナー `▸ ロボット判定を完了してください` |
+| API `captcha_failed` | フォーム上部バナー `▸ ロボット判定に失敗しました。再度お試しください` + widget リセット |
+| API `send_failed` / network / `internal` | フォーム上部バナー `▸ 送信に失敗しました。少し時間をおいて再度お試しください` |
+
+inline はフィールド単位、バナーは全体スコープのエラー、と役割を分離する。
+
+## 送信ボタンの活性条件
+
+| 条件 | ボタン |
+|---|---|
+| 必須項目に欠けがある or token なし | `disabled` |
+| すべて埋まっており token あり | `enabled` |
+| `submitting` 中 | `disabled` + `▸ sending...` |
+
+## Turnstile widget ライフサイクル
+
+1. `<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer />` を `next/head` で注入
+2. `<div className="cf-turnstile" data-sitekey={...} data-callback="onTurnstileSuccess" />` を ContactForm 内に配置
+3. callback で token を `useState` に保存
+4. 送信成功・失敗どちらでも `window.turnstile.reset()` でリセット（token 使い捨てのため）
+
+## 完了状態の表示
+
+```
+▸ message sent.
+
+ありがとうございます。
+通常 1〜3 営業日以内にお返事します。
+
+▸ back to home
+```
+
+- 1行目: `font-pixel text-[16px]`
+- 説明文: `font-jp text-[12px] mt-3 leading-[1.7] opacity-80`
+- 戻りリンク: `<Link href="/">` を `font-pixel text-[11px] underline mt-6 inline-block`
+
+## セキュリティ
+
+- メール本文は plain text のみ（HTML メールを作らない）
+- API ログにユーザー入力の内容を出さない（リーク防止）
+- `subject` のユーザー名は `\r`/`\n` を空白に置換してヘッダインジェクション防止
+- `TURNSTILE_SECRET_KEY` と `RESEND_API_KEY` は サーバー側のみで参照、クライアントへ露出させない
+
+## 受け入れ条件
+
+- [ ] `/contact` で名前・メール・本文・Turnstile を満たして送信すると、`miyata09x0084@gmail.com` に到着する
+- [ ] 受信メールの「返信」を押すと送信者のメールアドレス宛になる
+- [ ] 不正な入力（空、長すぎ、メール形式不正）はフィールド単位のエラーで弾かれる
+- [ ] Turnstile 未完了では送信ボタンが押せない
+- [ ] Turnstile 検証 API を直接叩いて偽 token を送ると 400 が返る
+- [ ] 送信成功でフォームが完了画面に置き換わる
+- [ ] 送信失敗でフォームが残り、上部にエラーバナーが出る
+- [ ] トップページの contact リンクが `/contact` を指している（Google Forms URL 削除）
+- [ ] `(google)` 文言が削除されている
+- [ ] 1-bit Mac モノクロ・pixel フォント・border invert ホバーが他ページと整合

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -86,6 +86,11 @@ const Home: NextPage<Props> = ({ posts }) => {
       <section className="px-5 py-5 border-t border-current">
         <SectionHeading>creations</SectionHeading>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-2.5">
+          <a href="https://github.com/miyata09x0084/daily-coworker" target="_blank" rel="noopener noreferrer" className="border border-current p-2.5 no-underline hover:bg-[var(--fg)] hover:text-[var(--bg)]">
+            <div className="font-pixel text-[11px]">DAILY COWORKER</div>
+            <div className="text-[11px] mt-1 opacity-85">Claude Code 上の個人 AI アシスタント</div>
+            <span className="inline-block mt-2 font-pixel text-[9px] opacity-60 border border-current px-1.5 py-px">AI · AGENT</span>
+          </a>
           <a href="https://slide-pilot-474305.web.app/" target="_blank" rel="noopener noreferrer" className="border border-current p-2.5 no-underline hover:bg-[var(--fg)] hover:text-[var(--bg)]">
             <div className="font-pixel text-[11px]">SLIDE PILOT</div>
             <div className="text-[11px] mt-1 opacity-85">Multimodal LLM で PDF を動画に変換</div>

--- a/pages/work/index.js
+++ b/pages/work/index.js
@@ -4,6 +4,12 @@ import { DitherBlock, StatusBar } from '../../components/ui';
 
 const works = [
   {
+    title: 'DAILY COWORKER',
+    href: 'https://github.com/miyata09x0084/daily-coworker',
+    desc: 'Claude Code 上に構築した個人向け AI アシスタント。スケジュール管理・リサーチ・記事執筆をスキルとして統合。',
+    tags: 'AI · AGENT',
+  },
+  {
     title: 'SLIDE PILOT',
     href: 'https://slide-pilot-474305.web.app/',
     desc: 'Multimodal LLM で PDF をスライド・ナレーション付き動画へ自動変換するエージェント。LangGraph で構築。',


### PR DESCRIPTION
## Summary
- `creations` 一覧の先頭に DAILY COWORKER（Claude Code 上に構築した個人 AI アシスタント）を追加
- `pages/work/index.js`（全件ページ）と `pages/index.tsx`（ホームのプレビュー）の両方に反映

## Test plan
- [ ] `npm run dev` でローカル起動し、`/` のホームの creations セクションに DAILY COWORKER が先頭表示されることを確認
- [ ] `/work` ページで全3件が表示され、StatusBar が `creations: 3` を表示することを確認
- [ ] DAILY COWORKER カードのリンクが GitHub リポジトリ（https://github.com/miyata09x0084/daily-coworker）に新規タブで遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new project showcase for "DAILY COWORKER" to the creations and work portfolio sections.

* **Documentation**
  * Added comprehensive design specification and implementation plan for an upcoming self-hosted contact form feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->