### PR TITLE
creations に DAILY COWORKER を追加

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -86,6 +86,11 @@ const Home: NextPage<Props> = ({ posts }) => {
       <section className="px-5 py-5 border-t border-current">
         <SectionHeading>creations</SectionHeading>
         <div className="grid grid-cols-1 md:grid-cols-2 gap-2.5">
+          <a href="https://github.com/miyata09x0084/daily-coworker" target="_blank" rel="noopener noreferrer" className="border border-current p-2.5 no-underline hover:bg-[var(--fg)] hover:text-[var(--bg)]">
+            <div className="font-pixel text-[11px]">DAILY COWORKER</div>
+            <div className="text-[11px] mt-1 opacity-85">Claude Code 上の個人 AI アシスタント</div>
+            <span className="inline-block mt-2 font-pixel text-[9px] opacity-60 border border-current px-1.5 py-px">AI · AGENT</span>
+          </a>
           <a href="https://slide-pilot-474305.web.app/" target="_blank" rel="noopener noreferrer" className="border border-current p-2.5 no-underline hover:bg-[var(--fg)] hover:text-[var(--bg)]">
             <div className="font-pixel text-[11px]">SLIDE PILOT</div>
             <div className="text-[11px] mt-1 opacity-85">Multimodal LLM で PDF を動画に変換</div>

--- a/pages/work/index.js
+++ b/pages/work/index.js
@@ -4,6 +4,12 @@ import { DitherBlock, StatusBar } from '../../components/ui';
 
 const works = [
   {
+    title: 'DAILY COWORKER',
+    href: 'https://github.com/miyata09x0084/daily-coworker',
+    desc: 'Claude Code 上に構築した個人向け AI アシスタント。スケジュール管理・リサーチ・記事執筆をスキルとして統合。',
+    tags: 'AI · AGENT',
+  },
+  {
     title: 'SLIDE PILOT',
     href: 'https://slide-pilot-474305.web.app/',
     desc: 'Multimodal LLM で PDF をスライド・ナレーション付き動画へ自動変換するエージェント。LangGraph で構築。',


### PR DESCRIPTION
## Summary
- `creations` 一覧の先頭に DAILY COWORKER（Claude Code 上に構築した個人 AI アシスタント）を追加
- `pages/work/index.js`（全件ページ）と `pages/index.tsx`（ホームのプレビュー）の両方に反映

## Test plan
- [ ] `npm run dev` でローカル起動し、`/` のホームの creations セクションに DAILY COWORKER が先頭表示されることを確認
- [ ] `/work` ページで全3件が表示され、StatusBar が `creations: 3` を表示することを確認
- [ ] DAILY COWORKER カードのリンクが GitHub リポジトリ（https://github.com/miyata09x0084/daily-coworker）に新規タブで遷移することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)